### PR TITLE
Harden Alibaba environment URL overrides

### DIFF
--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
@@ -15,7 +15,17 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
     public static func hostOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.hostKey])
+        guard let raw = self.cleaned(environment[self.hostKey]),
+              let url = self.validatedAlibabaURL(raw)
+        else {
+            return nil
+        }
+
+        guard let host = url.host else { return nil }
+        if let port = url.port {
+            return "\(host):\(port)"
+        }
+        return host
     }
 
     public static func cookieHeader(
@@ -28,10 +38,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         guard let raw = self.cleaned(environment[self.quotaURLKey]) else { return nil }
-        if let url = URL(string: raw), url.scheme != nil {
-            return url
-        }
-        return URL(string: "https://\(raw)")
+        return self.validatedAlibabaURL(raw)
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -48,6 +55,26 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+
+    private static func validatedAlibabaURL(_ raw: String) -> URL? {
+        let candidate: URL? = if let url = URL(string: raw), url.scheme != nil {
+            url
+        } else {
+            URL(string: "https://\(raw)")
+        }
+        guard let candidate else { return nil }
+        guard candidate.scheme?.lowercased() == "https" else { return nil }
+        guard let host = candidate.host?.lowercased(), self.isAllowedAlibabaHost(host) else {
+            return nil
+        }
+        return candidate
+    }
+
+    private static func isAllowedAlibabaHost(_ host: String) -> Bool {
+        let normalized = host.hasSuffix(".") ? String(host.dropLast()) : host
+        let suffixes = [".aliyun.com", ".alibabacloud.com", ".aliyuncs.com"]
+        return suffixes.contains { normalized == String($0.dropFirst()) || normalized.hasSuffix($0) }
     }
 }
 

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -25,6 +25,21 @@ struct AlibabaCodingPlanSettingsReaderTests {
     }
 
     @Test
+    func `quota URL rejects non HTTPS`() {
+        let url = AlibabaCodingPlanSettingsReader
+            .quotaURL(environment: [AlibabaCodingPlanSettingsReader
+                    .quotaURLKey: "http://modelstudio.console.alibabacloud.com/data/api.json"])
+        #expect(url == nil)
+    }
+
+    @Test
+    func `quota URL rejects non Alibaba hosts`() {
+        let url = AlibabaCodingPlanSettingsReader
+            .quotaURL(environment: [AlibabaCodingPlanSettingsReader.quotaURLKey: "https://example.com/data/api.json"])
+        #expect(url == nil)
+    }
+
+    @Test
     func `missing cookie error includes access hint when present`() {
         let error = AlibabaCodingPlanSettingsError
             .missingCookie(details: "Safari cookie file exists but is not readable.")
@@ -644,9 +659,16 @@ struct AlibabaCodingPlanRegionTests {
 
     @Test
     func `quota url override beats host`() {
+        let env = [AlibabaCodingPlanSettingsReader.quotaURLKey: "https://custom.aliyun.com/custom/quota"]
+        let url = AlibabaCodingPlanUsageFetcher.resolveQuotaURL(region: .international, environment: env)
+        #expect(url.absoluteString == "https://custom.aliyun.com/custom/quota")
+    }
+
+    @Test
+    func `invalid quota url override falls back to region endpoint`() {
         let env = [AlibabaCodingPlanSettingsReader.quotaURLKey: "https://example.com/custom/quota"]
         let url = AlibabaCodingPlanUsageFetcher.resolveQuotaURL(region: .international, environment: env)
-        #expect(url.absoluteString == "https://example.com/custom/quota")
+        #expect(url == AlibabaCodingPlanAPIRegion.international.quotaURL)
     }
 }
 
@@ -743,7 +765,7 @@ struct AlibabaCodingPlanUsageFetcherRequestTests {
 
         AlibabaConsoleSECTokenStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
-            #expect(url.host == "alibaba-proxy.test")
+            #expect(url.host == "alibaba-proxy.aliyun.com")
 
             if request.httpMethod == "GET", url.path == AlibabaCodingPlanAPIRegion.international.dashboardURL.path {
                 return Self.makeResponse(url: url, body: "<html></html>", statusCode: 200)
@@ -783,7 +805,7 @@ struct AlibabaCodingPlanUsageFetcherRequestTests {
         let snapshot = try await AlibabaCodingPlanUsageFetcher.fetchUsage(
             cookieHeader: "sec_token=cookie-sec-token; login_aliyunid_ticket=ticket; login_aliyunid_pk=user",
             region: .international,
-            environment: [AlibabaCodingPlanSettingsReader.hostKey: "https://alibaba-proxy.test"],
+            environment: [AlibabaCodingPlanSettingsReader.hostKey: "https://alibaba-proxy.aliyun.com"],
             now: Date(timeIntervalSince1970: 1_700_000_000))
 
         #expect(snapshot.planName == "Alibaba Coding Plan Pro")


### PR DESCRIPTION
### Motivation
- Environment overrides `ALIBABA_CODING_PLAN_HOST` and `ALIBABA_CODING_PLAN_QUOTA_URL` allowed arbitrary or non-HTTPS URLs and could cause sensitive API keys/cookies to be sent to attacker-controlled endpoints. 
- The change aims to prevent credential exfiltration by validating and restricting environment-supplied hosts/URLs while preserving existing fallback behavior.

### Description
- Add a shared validator `validatedAlibabaURL(_:)` that normalizes an input, enforces `https` and restricts hosts to Alibaba-owned suffixes (`aliyun.com`, `alibabacloud.com`, `aliyuncs.com`).
- Make `quotaURL(...)` use the validator so invalid/non-HTTPS/non-Alibaba overrides return `nil` and trigger existing region fallbacks. 
- Normalize `hostOverride(...)` to return `host` or `host:port` after validation so downstream URL composition continues to work safely. 
- Add focused regression tests in `Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift` for rejecting HTTP/non-Alibaba overrides, for invalid-override fallback behavior, and update a test fixture domain to an allowed Alibaba suffix.

### Testing
- Ran `pnpm check` which failed in this environment due to the SwiftFormat archive not containing the expected `swiftformat` binary. (failure)
- Ran `./Scripts/compile_and_run.sh` which failed in this environment because the installed Swift tools version (`6.1.3`) is older than the package's required version (`6.2.0`). (failure)
- Added unit tests for the new validation behavior but no local test run completed due to the environment toolchain/formatting failures above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3878c66148320896ee699bd3457d3)